### PR TITLE
updates to resolve FruitProviderFactory warnings during maven build

### DIFF
--- a/src/main/java/com/redhat/rotation/market/FruitProviderFactory.java
+++ b/src/main/java/com/redhat/rotation/market/FruitProviderFactory.java
@@ -1,5 +1,6 @@
 package com.redhat.rotation.market;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.Produces;
@@ -15,16 +16,22 @@ import com.redhat.rotation.market.service.FruitServiceMongo;
 public class FruitProviderFactory {
     FruitService fruitService;
 
+    public FruitProviderFactory() { } 
+
     /**
      * By default the memory based storage will be used.
      * 
      * @param ephemeral true if we want to use a simple list to store the fruits,
      *                  otherwise it would use a MongoDB instance.
      */
-    @Inject
-    FruitProviderFactory(@ConfigProperty(name = "fruit.storage.ephemeral", defaultValue = "true") boolean ephemeral) {
-        fruitService = getFruitService(ephemeral);
-    }
+
+    @ConfigProperty(name = "fruit.storage.ephemeral", defaultValue = "true")
+    javax.enterprise.inject.Instance<Boolean> ephemeral;
+
+    @PostConstruct
+    public void setup() {
+        fruitService = getFruitService(ephemeral.get().booleanValue());        
+    }    
 
     @Produces
     @ApplicationScoped


### PR DESCRIPTION
@wkulhanek

This PR resolves the maven build warning

```
[WARNING] [io.quarkus.resteasy.common.deployment.ResteasyCommonProcessor] 
Classes annotated with @Provider should have a single, no-argument constructor, 
otherwise dependency injection won't work properly. Offending class 
is com.redhat.rotation.market.FruitProviderFactory
```

The app works as expected. However, it is a good idea to resolve this in case other enhancements are added in the future. I performed minor restructuring of the code for the class FruitProviderFactory.java
- Added single no-arg constructor
- Removed existing constructor and replaced with 
   - `@ConfigProperty` to inject the configuration property for `fruit.storage.ephemeral`
   - Added `@PostConstruct` method to initialize `FruitService` based on `ephemeral` field